### PR TITLE
refactor: move quickStartQueries and ipDetails logic to prompt-box

### DIFF
--- a/app/_components/prompt-box.tsx
+++ b/app/_components/prompt-box.tsx
@@ -2,19 +2,26 @@
 import ShineBorder from "@/components/magicui/shine-border"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { generateTypeSuggestion } from "@/lib/queries"
+import { fetchIpDetails, generateTypeSuggestion } from "@/lib/queries"
 import { TQueryData } from "@/lib/types"
-import { quickStartQueries } from "@/lib/utils"
 import useEditFormPageStore from "@/store/editFormPageStore"
 import useFormVersionStore from "@/store/formVersions"
 import { ArrowRight, ArrowUpRight, Loader2 } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { Fragment, useEffect, useRef, useState, useTransition } from "react"
+import {
+  Fragment,
+  use,
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+} from "react"
 import { v4 as uuidv4 } from "uuid"
 import { addFormQueryToDb } from "../_actions/formAction"
 import AnimatedPlaceholderInput from "./animated-placeholder-input"
 import TemplateAndScratch from "./template-and-scratch"
 import { toast } from "react-hot-toast"
+import { useQuery } from "@tanstack/react-query"
 
 const PromptBox = () => {
   const router = useRouter()
@@ -68,6 +75,30 @@ const PromptBox = () => {
       }
     }
   }, [query])
+
+  const { data: ipDetails, isLoading } = useQuery({
+    queryKey: ["ipDetails"],
+    queryFn: fetchIpDetails,
+  })
+
+  const quickStartQueries = [
+    {
+      id: 1,
+      query: "User feedback survey",
+    },
+    {
+      id: 2,
+      query: "A job application form",
+    },
+    {
+      id: 3,
+      query: "Form for e-bike market research",
+    },
+    {
+      id: 4,
+      query: `Make a quiz about ${ipDetails?.country ?? "AI"}`,
+    },
+  ]
 
   const handleSubmit = async (formData: FormData) => {
     const data = Object.fromEntries(formData.entries()) as TQueryData

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,12 +4,10 @@ import Header from "./_components/header"
 import IntroSection from "./_components/intro-section"
 import PromptBox from "./_components/prompt-box"
 import { RecentForms } from "./_components/recent-forms"
-import { fetchIpDetails } from "@/lib/queries"
 
 export default async function Home() {
   const supabase = await createClient()
   const { data: user, error: userError } = await supabase.auth.getUser()
-  const ipData = await fetchIpDetails()
   return (
     <>
       <div className="min-h-screen flex flex-col z-10 relative">
@@ -33,7 +31,7 @@ export default async function Home() {
         <main className="flex flex-grow w-full">
           <div className="m-auto w-[80%] md:w-[60%] px-3 py-2 flex gap-5 flex-col">
             <div className="flex justify-center">
-              <ShiningBadge>{ipData.country}</ShiningBadge>
+              <ShiningBadge> Celebrating 500+ Users 🎉 </ShiningBadge>
             </div>
             <div className="flex flex-col gap-5 font-bricolage_grotesque">
               <IntroSection />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,7 +5,7 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-export const quickStartQueries = [
+const quickStartQueries = [
   {
     id: 1,
     query: "User feedback survey",


### PR DESCRIPTION
Move the `quickStartQueries` array and `fetchIpDetails` logic from `utils.ts` and `page.tsx` to `prompt-box.tsx` for better encapsulation and maintainability. Update the `ShiningBadge` content to celebrate 500+ users.